### PR TITLE
Support for shades and automatic discovery

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+0.3.0 (2020-09-28)
+
+- Support for Shades/Blinds
+- Access to more parts of the Dingz API
+  (Blind Config, System Config and others)
+- Automatic discovery for Dingz units in the local network
+
 0.2.0 (2020-05-20)
 ------------------
 

--- a/dingz/constants.py
+++ b/dingz/constants.py
@@ -21,12 +21,15 @@ DEVICE_INFO = "device"
 LIGHT = "light"
 SCHEDULE = "schedule"
 TIMER = "timer"
+SHADE = "shade"
+STATE = "state"
 
 # Special endpoints
 LOG = "/log"
 FIRMWARE = "/load"
 
 SETTINGS = "settings"
+SYSTEM_CONFIG = "system_config"
 FRONT_LED_GET = "led/get"
 FRONT_LED_SET = "led/set"
 BUTTON_ACTIONS = "action"
@@ -34,6 +37,7 @@ WIFI_SCAN = "scan"
 
 # Configuration endpoints
 PIR_CONFIGURATION = "pir_config"
+BLIND_CONFIGURATION = "blind_config"
 THERMOSTAT_CONFIGURATION = "thermostat_config"
 INPUT_CONFIGURATION = "input_config"
 

--- a/dingz/discovery.py
+++ b/dingz/discovery.py
@@ -1,9 +1,9 @@
-
 import asyncio
 import logging
 from typing import Optional, List
 
 _LOGGER = logging.getLogger(__name__)
+
 
 class DiscoveredDevice(object):
     mac: str
@@ -15,13 +15,15 @@ class DiscoveredDevice(object):
 
     @staticmethod
     def create_from_announce_msg(raw_addr, announce_msg):
+        _LOGGER.debug("received announce msg '%s' from %s ", announce_msg, raw_addr)
         if len(announce_msg) != 8:
-            raise RuntimeError("unexpected announcement, %s" % announce_msg)
+            raise RuntimeError("unexpected announcement, '%s'" % announce_msg)
 
-        device = DiscoveredDevice(host=raw_addr[0],
-                                  mac=announce_msg[0:6].hex(":"))
+        device = DiscoveredDevice(host=raw_addr[0], mac=announce_msg[0:6].hex(":"))
         device.type = announce_msg[6]
         status = announce_msg[7]
+
+        # parse status field
         device.is_child = status & 1 != 0
         device.mystrom_registered = status & 2 != 0
         device.mystrom_online = status & 4 != 0
@@ -31,22 +33,6 @@ class DiscoveredDevice(object):
     def __init__(self, host, mac):
         self.host = host
         self.mac = mac
-
-
-class DiscoveryProtocol(asyncio.DatagramProtocol):
-    def __init__(self, registry):
-        super().__init__()
-        self.registry = registry
-
-    def connection_made(self, transport):
-        self.transport = transport
-
-    def datagram_received(self, data, addr):
-        device = DiscoveredDevice.create_from_announce_msg(addr, data)
-        self.registry.register(device)
-
-    def connection_lost(self, exc: Optional[Exception]) -> None:
-        super().connection_lost(exc)
 
 
 class DeviceRegistry(object):
@@ -60,21 +46,56 @@ class DeviceRegistry(object):
         return list(self.devices_by_mac.values())
 
 
-async def discover_dingz_devices(timeout=7) -> List[DiscoveredDevice]:
+class DiscoveryProtocol(asyncio.DatagramProtocol):
+    def __init__(self, registry: DeviceRegistry):
+        super().__init__()
+        self.registry = registry
+
+    def connection_made(self, transport):
+        _LOGGER.debug("starting up udp listener")
+        self.transport = transport
+
+    def datagram_received(self, data, addr):
+        device = DiscoveredDevice.create_from_announce_msg(addr, data)
+        self.registry.register(device)
+
+    def connection_lost(self, exc: Optional[Exception]) -> None:
+        _LOGGER.debug("shutting down udp listener")
+        super().connection_lost(exc)
+
+
+async def discover_dingz_devices(timeout: int = 7) -> List[DiscoveredDevice]:
+    """
+    Try to discover all local dingz instances. All dingz instances
+    report their presence every ~5 seconds in a UDP broadcast to port 7979.
+
+    :param timeout: timeout in seconds for discover.
+    :return: list of discovered devices
+    """
     registry = DeviceRegistry()
     loop = asyncio.get_event_loop()
-    (transport, protocol) = await loop.create_datagram_endpoint(lambda: DiscoveryProtocol(registry), local_addr=("0.0.0.0", 7979))
-
+    (transport, protocol) = await loop.create_datagram_endpoint(
+        lambda: DiscoveryProtocol(registry), local_addr=("0.0.0.0", 7979)
+    )
+    # server runs in the background, meanwhile wait until timeout expires
     await asyncio.sleep(timeout)
+
+    # shutdown server
     transport.close()
+
     devices = registry.devices()
+    for device in devices:
+        _LOGGER.debug(
+            "discovered dingz %s (%s) with mac %s", device.host, device.type, device.mac
+        )
     return devices
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
     loop = asyncio.get_event_loop()
     devices = asyncio.run(discover_dingz_devices())
 
     print("found %s devices" % len(devices))
     for device in devices:
-        print(f'{device.mac} {device.host}')
+        print(f"{device.mac} {device.host}")

--- a/dingz/discovery.py
+++ b/dingz/discovery.py
@@ -1,0 +1,80 @@
+
+import asyncio
+import logging
+from typing import Optional, List
+
+_LOGGER = logging.getLogger(__name__)
+
+class DiscoveredDevice(object):
+    mac: str
+    type: int
+    is_child: bool
+    mystrom_registered: bool
+    mystrom_online: bool
+    restarted: bool
+
+    @staticmethod
+    def create_from_announce_msg(raw_addr, announce_msg):
+        if len(announce_msg) != 8:
+            raise RuntimeError("unexpected announcement, %s" % announce_msg)
+
+        device = DiscoveredDevice(host=raw_addr[0],
+                                  mac=announce_msg[0:6].hex(":"))
+        device.type = announce_msg[6]
+        status = announce_msg[7]
+        device.is_child = status & 1 != 0
+        device.mystrom_registered = status & 2 != 0
+        device.mystrom_online = status & 4 != 0
+        device.restarted = status & 8 != 0
+        return device
+
+    def __init__(self, host, mac):
+        self.host = host
+        self.mac = mac
+
+
+class DiscoveryProtocol(asyncio.DatagramProtocol):
+    def __init__(self, registry):
+        super().__init__()
+        self.registry = registry
+
+    def connection_made(self, transport):
+        self.transport = transport
+
+    def datagram_received(self, data, addr):
+        device = DiscoveredDevice.create_from_announce_msg(addr, data)
+        self.registry.register(device)
+
+    def connection_lost(self, exc: Optional[Exception]) -> None:
+        super().connection_lost(exc)
+
+
+class DeviceRegistry(object):
+    def __init__(self):
+        self.devices_by_mac = {}
+
+    def register(self, device):
+        self.devices_by_mac[device.mac] = device
+
+    def devices(self):
+        return list(self.devices_by_mac.values())
+
+
+async def discover_dingz_devices(timeout=7) -> List[DiscoveredDevice]:
+    registry = DeviceRegistry()
+    loop = asyncio.get_event_loop()
+    (transport, protocol) = await loop.create_datagram_endpoint(lambda: DiscoveryProtocol(registry), local_addr=("0.0.0.0", 7979))
+
+    await asyncio.sleep(timeout)
+    transport.close()
+    devices = registry.devices()
+    return devices
+
+
+if __name__ == "__main__":
+    loop = asyncio.get_event_loop()
+    devices = asyncio.run(discover_dingz_devices())
+
+    print("found %s devices" % len(devices))
+    for device in devices:
+        print(f'{device.mac} {device.host}')

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ if sys.argv[-1] == "publish":
 
 setup(
     name="python-dingz",
-    version="0.2.0",
+    version="0.3.0-dev1",
     description="Python API for interacting with Dingz devices",
     long_description=long_description,
     url="https://github.com/fabaff/python-dingz",


### PR DESCRIPTION
Hi @fabaff 

As mentioned a few months agao I've extended the dingz api client. It now supports operating and fetching data from the shades, some other api endpoints, and an automatic discovery for dingz devices. 

I don't expect that you merge the PR as it is, but I'd like to invite you to give me feedback. Do you have any issues with terminology? Maybe should we refactor the whole shade handling to a dedicated class? What do you think about the device discovery?

Right now I only have one dingz unit, with both pins set to 'blind', i.e. I cannot really test how it behaves with just one or no blind. 

Cheers!
Reto