### PR TITLE
Don't depend on async-timeout for Python 3.11+.

### DIFF
--- a/dingz/__init__.py
+++ b/dingz/__init__.py
@@ -4,7 +4,11 @@ import socket
 from typing import Any, Mapping, Optional
 
 import aiohttp
-import async_timeout
+import sys
+if sys.version_info >= (3, 11):
+    import asyncio as async_timeout
+else:
+    import async_timeout
 
 from .constants import TIMEOUT, USER_AGENT, CONTENT_TYPE_JSON, CONTENT_TYPE, CONTENT_TYPE_TEXT_PLAIN
 from .exceptions import DingzConnectionError

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     author="Fabian Affolter",
     author_email="fabian@affolter-engineering.ch",
     license="Apache License 2.0",
-    install_requires=["aiohttp<4", "async_timeout<5", "click", "setuptools"],
+    install_requires=["aiohttp<4", "async_timeout; python_version < \"3.11\"", "click", "setuptools"],
     packages=find_packages(),
     python_requires='>=3.9',
     zip_safe=True,


### PR DESCRIPTION
This library was upstreamed into the standard library and is thus deprecated.